### PR TITLE
Load methods from method manifest

### DIFF
--- a/Zuse.xcodeproj/project.pbxproj
+++ b/Zuse.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		5F8138D41898C36B009F3495 /* NSNumber+Zuse.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F8138D31898C36B009F3495 /* NSNumber+Zuse.m */; };
 		5F8138D9189A1DF1009F3495 /* ZSComponentNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F8138D8189A1DF1009F3495 /* ZSComponentNode.m */; };
 		5F8138DF18A0BA07009F3495 /* ZSCollisionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F8138DE18A0BA07009F3495 /* ZSCollisionsViewController.m */; };
+		5FADD82018D7DD2B00A336CC /* ZSZuseDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FADD81F18D7DD2B00A336CC /* ZSZuseDSL.m */; };
+		5FADD82218D7E98400A336CC /* ZSZuseDSLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FADD82118D7E98400A336CC /* ZSZuseDSLTests.m */; };
 		5FB05F2018C44B6600356531 /* ZS_VariableChooserCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FB05F1F18C44B6600356531 /* ZS_VariableChooserCollectionViewController.m */; };
 		5FBB4A7D18BFE90A00B79AB6 /* ZSProjectCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FBB4A7C18BFE90A00B79AB6 /* ZSProjectCollectionViewCell.m */; };
 		5FBB4A8018BFEA4300B79AB6 /* ZSMainMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FBB4A7F18BFEA4300B79AB6 /* ZSMainMenuViewController.m */; };
@@ -394,6 +396,9 @@
 		5F8138DB189CA574009F3495 /* ZSGroupsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZSGroupsViewController.m; sourceTree = "<group>"; };
 		5F8138DD18A0BA07009F3495 /* ZSCollisionsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZSCollisionsViewController.h; sourceTree = "<group>"; };
 		5F8138DE18A0BA07009F3495 /* ZSCollisionsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZSCollisionsViewController.m; sourceTree = "<group>"; };
+		5FADD81E18D7DD2B00A336CC /* ZSZuseDSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZSZuseDSL.h; sourceTree = "<group>"; };
+		5FADD81F18D7DD2B00A336CC /* ZSZuseDSL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZSZuseDSL.m; sourceTree = "<group>"; };
+		5FADD82118D7E98400A336CC /* ZSZuseDSLTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZSZuseDSLTests.m; sourceTree = "<group>"; };
 		5FB05F1E18C44B6600356531 /* ZS_VariableChooserCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZS_VariableChooserCollectionViewController.h; sourceTree = "<group>"; };
 		5FB05F1F18C44B6600356531 /* ZS_VariableChooserCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZS_VariableChooserCollectionViewController.m; sourceTree = "<group>"; };
 		5FBB4A7B18BFE90A00B79AB6 /* ZSProjectCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZSProjectCollectionViewCell.h; sourceTree = "<group>"; };
@@ -673,6 +678,8 @@
 				4CE35622188B0810007024C0 /* View Controllers */,
 				7899785F18B9255500A8FE05 /* ZS_JsonViewController.h */,
 				7899786018B9255500A8FE05 /* ZS_JsonViewController.m */,
+				5FADD81E18D7DD2B00A336CC /* ZSZuseDSL.h */,
+				5FADD81F18D7DD2B00A336CC /* ZSZuseDSL.m */,
 			);
 			name = Editor;
 			sourceTree = "<group>";
@@ -917,6 +924,7 @@
 				5F6AD25718BD948700299AB8 /* ZSCodePropertyScopeTests.m */,
 				5F57B13E18D4FA70007DB634 /* ZSCodeTraverserTests.m */,
 				5F57B14318D538CA007DB634 /* ZSCodeTransformsTests.m */,
+				5FADD82118D7E98400A336CC /* ZSZuseDSLTests.m */,
 				4CF1CBD717EF882A00636E0D /* Supporting Files */,
 			);
 			path = ZuseTests;
@@ -1394,6 +1402,7 @@
 				4C4087091852480F009117E1 /* ZSSpriteLibrary.m in Sources */,
 				2CA9D387183F3F0300401231 /* ZSRendererScene.m in Sources */,
 				2CA9A32A18C26605005F4404 /* ZSZuseHubSideMenuViewController.m in Sources */,
+				5FADD82018D7DD2B00A336CC /* ZSZuseDSL.m in Sources */,
 				2CA9A33918C481FE005F4404 /* ZSZuseHubJSONClient.m in Sources */,
 				2CA9A32D18C26E27005F4404 /* ZSZuseHubViewController.m in Sources */,
 				7899786218B9255500A8FE05 /* ZS_StatementView.m in Sources */,
@@ -1414,6 +1423,7 @@
 				5F6AD25818BD948700299AB8 /* ZSCodePropertyScopeTests.m in Sources */,
 				5F099D4817F1136000EB2AC7 /* InterpreterTests.m in Sources */,
 				5F2EC4DC183AD7510091CEAD /* ZSInterpreterDelegateTests.m in Sources */,
+				5FADD82218D7E98400A336CC /* ZSZuseDSLTests.m in Sources */,
 				5F2EC4D8183ABF160091CEAD /* ZSCompilerTests.m in Sources */,
 				5F39DFD7188A472E008ECAC1 /* ZSInterpreterExpressionTests.m in Sources */,
 			);

--- a/Zuse/JSON/method_manifest.json
+++ b/Zuse/JSON/method_manifest.json
@@ -22,5 +22,23 @@
     "name": "square root",
     "return_type": "numeric",
     "parameters": []
+  },
+  {
+    "name": "generate",
+    "return_type": "none",
+    "parameters": [
+      {
+        "name": "name",
+        "types": ["string"]
+      },
+      {
+        "name": "x",
+        "types": ["numeric"]
+      },
+      {
+        "name": "y",
+        "types": ["numeric"]
+      }
+    ]
   }
 ]

--- a/Zuse/ZSZuseDSL.h
+++ b/Zuse/ZSZuseDSL.h
@@ -1,0 +1,20 @@
+//
+//  ZSZuseDSL.h
+//  Zuse
+//
+//  Created by Parker Wightman on 3/17/14.
+//  Copyright (c) 2014 Michael Hogenson. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ZSZuseDSL : NSObject
+
++ (NSDictionary *)onEventJSON;
++ (NSDictionary *)triggerEventJSON;
++ (NSDictionary *)ifJSON;
++ (NSDictionary *)setJSON;
+
++ (NSDictionary *)callFromManifestJSON:(NSDictionary *)entry;
+
+@end

--- a/Zuse/ZSZuseDSL.m
+++ b/Zuse/ZSZuseDSL.m
@@ -1,0 +1,63 @@
+//
+//  ZSZuseDSL.m
+//  Zuse
+//
+//  Created by Parker Wightman on 3/17/14.
+//  Copyright (c) 2014 Michael Hogenson. All rights reserved.
+//
+
+#import "ZSZuseDSL.h"
+#import "BlocksKit.h"
+
+@implementation ZSZuseDSL
+
++ (NSDictionary *)onEventJSON {
+    return @{
+        @"on_event": @{
+            @"name": @"#event name",
+            @"parameters": @[],
+            @"code": @[]
+        }
+    };
+}
+
++ (NSDictionary *)triggerEventJSON {
+    return @{
+        @"trigger_event": @{
+            @"name": @"#event name",
+            @"parameters": @{}
+        }
+    };
+}
+
++ (NSDictionary *)ifJSON {
+    return @{
+        @"if": @{
+            @"test": @"#expression",
+            @"true": @[]
+        }
+    };
+}
+
++ (NSDictionary *)setJSON {
+    return @{
+        @"set": @[@"#name", @"#value"]
+    };
+}
+
++ (NSDictionary *)callFromManifestJSON:(NSDictionary *)entry {
+    NSMutableDictionary * call = [@{
+        @"call": @{
+            @"method": entry[@"name"],
+            @"parameters": @[]
+        }
+    } deepMutableCopy];
+    
+    call[@"call"][@"parameters"] = [entry[@"parameters"] map:^id(NSDictionary *entryInfo) {
+        return [@"#" stringByAppendingString:entryInfo[@"name"]];
+    }];
+    
+    return call;
+}
+
+@end

--- a/Zuse/ZS_CodeEditorViewController.m
+++ b/Zuse/ZS_CodeEditorViewController.m
@@ -1,5 +1,8 @@
+#import <MTBlockAlertView/MTBlockAlertView.h>
+
 #import "ZS_CodeEditorViewController.h"
 #import "ZS_JsonUtilities.h"
+#import "ZSZuseDSL.h"
 
 #import "ZS_ExpressionViewController.h"
 #import "ZS_JsonViewController.h"
@@ -355,14 +358,35 @@
     [view addNameLabelWithText:@"("];
     
     // Method parameters
-    NSArray* parameters = json[@"call"][@"parameters"];
+    
+    // The manifest parameters hold extra metadata about what each parameter accepts
+    NSArray *manifestParameters = [ZS_JsonUtilities manifestForMethodIdentifier:json[@"call"][@"method"]][@"parameters"];
+    NSMutableArray *parameters = json[@"call"][@"parameters"];
     for (NSInteger i = 0; i < parameters.count; i++)
     {
+        NSDictionary *manifestParameter = manifestParameters[i];
         [view addArgumentLabelWithText: [ZS_JsonUtilities expressionStringFromJson: parameters[i]]
                             touchBlock:^(UILabel* label)
          {
              label.tag = i;
-             [self performSegueWithIdentifier:@"to expression editor" sender: label];
+             if ([manifestParameter[@"types"][0] isEqualToString:@"string"]) {
+                 UIAlertView *alertView = [[MTBlockAlertView alloc] initWithTitle:@"String Value"
+                                                                          message:@"Enter a string"
+                                                                completionHanlder:^(UIAlertView *alertView, NSInteger buttonIndex) {
+                                                                    NSString *text = [alertView textFieldAtIndex:0].text;
+                                                                    if (text && text.length > 0) {
+                                                                        parameters[i] = text;
+                                                                        label.text = text;
+                                                                    }
+                                                                }
+                                                                cancelButtonTitle:@"Cancel"
+                                                                otherButtonTitles:@"OK", nil];
+                 
+                alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
+                [alertView show];
+             } else {
+                 [self performSegueWithIdentifier:@"to expression editor" sender: label];
+             }
          }];
 
         // Comma

--- a/Zuse/ZS_JsonUtilities.h
+++ b/Zuse/ZS_JsonUtilities.h
@@ -8,4 +8,6 @@
 + (NSString*) expressionStringFromJson: (NSObject*) json;
 + (NSArray*) emptyStatements;
 + (NSArray*) emptyEvents;
++ (NSArray*) emptyMethods;
++ (NSDictionary *)manifestForMethodIdentifier:(NSString *)identifier;
 @end

--- a/Zuse/ZS_JsonUtilities.m
+++ b/Zuse/ZS_JsonUtilities.m
@@ -1,4 +1,6 @@
 #import "ZS_JsonUtilities.h"
+#import "ZSZuseDSL.h"
+#import "BlocksKit.h"
 
 @implementation ZS_JsonUtilities
 
@@ -119,60 +121,61 @@
     }
     return nil;
 }
+
 + (NSArray*) emptyStatements
 {
-    NSMutableArray* statements = [[NSMutableArray alloc]init];
-    NSMutableDictionary* statement;
+    static NSArray *statements = nil;
     
-    // On event
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"on_event"] = [[NSMutableDictionary alloc]init];
-    statement[@"on_event"][@"name"] = @"#event name";
-    statement[@"on_event"][@"parameters"] = [[NSMutableArray alloc]init];
-    statement[@"on_event"][@"code"] = [[NSMutableArray alloc]init];
-    [statements addObject:statement];
+    if (!statements) {
+        statements = @[
+            [[ZSZuseDSL onEventJSON] deepMutableCopy],
+            [[ZSZuseDSL triggerEventJSON] deepMutableCopy],
+            [[ZSZuseDSL ifJSON] deepMutableCopy],
+            [[ZSZuseDSL setJSON] deepMutableCopy]
+        ];
+    }
     
-    // Trigger event
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"trigger_event"] = [[NSMutableDictionary alloc]init];
-    statement[@"trigger_event"][@"name"] = @"#event name";
-    statement[@"trigger_event"][@"parameters"] = [[NSMutableDictionary alloc]init];
-    [statements addObject:statement];
-    
-    // If
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"if"] = [[NSMutableDictionary alloc]init];
-    statement[@"if"][@"test"] = @"#expression";
-    statement[@"if"][@"true"] = [[NSMutableArray alloc]init];
-    [statements addObject:statement];
-    
-    // Set
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"set"] = [NSMutableArray arrayWithArray: @[@"#name", @"#value"]];
-    [statements addObject:statement];
-    
-    // Call move
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"call"] = [[NSMutableDictionary alloc]init];
-    statement[@"call"][@"method"] = @"move";
-    statement[@"call"][@"parameters"] = [NSMutableArray arrayWithArray:@[@"#var", @"#var"]];
-    [statements addObject:statement];
-
-    // Call remove
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"call"] = [[NSMutableDictionary alloc]init];
-    statement[@"call"][@"method"] = @"remove";
-    statement[@"call"][@"parameters"] = [NSMutableArray arrayWithArray:@[]];
-    [statements addObject:statement];
-    
-    // Call square root
-    statement = [[NSMutableDictionary alloc]init];
-    statement[@"call"] = [[NSMutableDictionary alloc]init];
-    statement[@"call"][@"method"] = @"square root";
-    statement[@"call"][@"parameters"] = [NSMutableArray arrayWithArray:@[]];
-    [statements addObject:statement];
-
     return statements;
+}
+
++ (NSArray *)methodManfiest {
+    static NSArray *methodManifest = nil;
+    
+    if (!methodManifest) {
+        NSString *path = [[NSBundle mainBundle] pathForResource:@"method_manifest" ofType:@"json"];
+        NSData *data = [NSData dataWithContentsOfFile:path];
+        
+        NSError *error = nil;
+        methodManifest = [NSJSONSerialization JSONObjectWithData:data
+                                                                   options:0
+                                                                     error:&error];
+        assert(!error);
+    }
+    
+    return methodManifest;
+}
+
+// TODO: This could be sped up by creating a dictionary from the array,
+// but I don't foresee it being called enough to slow anything down.
+//   - Parker
++ (NSDictionary *)manifestForMethodIdentifier:(NSString *)identifier {
+    return [[self methodManfiest] match:^BOOL(NSDictionary *manifestItem) {
+        return [manifestItem[@"name"] isEqualToString:identifier];
+    }];
+}
+
++ (NSArray *)emptyMethods {
+
+    static NSArray *methods = nil;
+    
+    if (!methods) {
+        NSArray *manifestMethods = [self methodManfiest];
+        methods = [manifestMethods map:^id(NSDictionary *manifestJSON) {
+            return [ZSZuseDSL callFromManifestJSON:manifestJSON];
+        }];
+    }
+    
+    return methods;
 }
 
 + (NSArray*) emptyEvents

--- a/Zuse/ZS_StatementChooserCollectionViewController.m
+++ b/Zuse/ZS_StatementChooserCollectionViewController.m
@@ -36,7 +36,7 @@
 {
     if (!_statements)
     {
-        _statements = [ZS_JsonUtilities emptyStatements];
+        _statements = [[ZS_JsonUtilities emptyStatements] arrayByAddingObjectsFromArray:[ZS_JsonUtilities emptyMethods]];;
     }
     return _statements;
 }

--- a/ZuseTests/ZSZuseDSLTests.m
+++ b/ZuseTests/ZSZuseDSLTests.m
@@ -1,0 +1,47 @@
+//
+//  ZSZuseDSLTests.m
+//  Zuse
+//
+//  Created by Parker Wightman on 3/17/14.
+//  Copyright (c) 2014 Michael Hogenson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "ZSZuseDSL.h"
+
+@interface ZSZuseDSLTests : XCTestCase
+
+@end
+
+@implementation ZSZuseDSLTests
+
+- (void)testCallFromManifestJSON
+{
+    NSDictionary *manifest = @{
+        @"name": @"move",
+        @"return_type": @"none",
+        @"parameters": @[
+            @{
+                @"name": @"direction",
+                @"types": @[@"numeric"]
+            },
+            @{
+                @"name": @"speed",
+                @"types": @[@"numeric"]
+            }
+        ]
+    };
+      
+    NSDictionary *actual = [ZSZuseDSL callFromManifestJSON:manifest];
+    
+    NSDictionary *expected = @{
+        @"call": @{
+            @"method": @"move",
+            @"parameters": @[@"#direction", @"#speed"]
+        }
+    };
+    
+    XCTAssertEqualObjects(expected, actual, @"");
+}
+
+@end


### PR DESCRIPTION
Methods are now loaded from the method manifest. Created new ZSZuseDSL (stands for Domain-Specific Language) class which holds the canonical forms of statements and expressions that the editor understands. Created one applicable test. Either @mhogenso or @vladimirzhidkov I'd appreciate a code review.
